### PR TITLE
修改图表标题格式

### DIFF
--- a/Style/gzhuThesis.sty
+++ b/Style/gzhuThesis.sty
@@ -96,9 +96,9 @@ hyperindex, plainpages=false]{hyperref}
 {\thecontentslabel\quad}{}
 {\hspace{.5em}\titlerule*[1em]{$\cdot$}\contentspage}
 \numberwithin{equation}{section}\numberwithin{figure}{section}\numberwithin{table}{section}
-\renewcommand{\thefigure}{\thesection.\arabic{figure}}
+\renewcommand{\thefigure}{\thesection-\arabic{figure}}
 \renewcommand{\thesubfigure}{\thefigure-(\alph{subfigure})}
-\renewcommand{\thetable}{\thesection.\arabic{table}}
+\renewcommand{\thetable}{\thesection-\arabic{table}}
 \allowdisplaybreaks%允许公式换页
 \parindent=2em%新段缩进量
 \def\@define@term#1{


### PR DESCRIPTION
根据广州大学研究生学位论文要求，图表标题格式应为图1-1、图2-1，表1-1、表2-1等，而非使用图1.1、图2.1、表1.1。