### PR TITLE
 font compatible with Mac

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -15,6 +15,10 @@
 \setCJKmainfont{SimSun}
 \setCJKmonofont{SimSun}% 设置缺省中文字体
 \setCJKfamilyfont{hei}{SimHei} %黑体  hei
+% Mac 字体名称与 Windows 不同，需要将宋体和黑体替换为下述注释中内容
+% \setCJKmainfont{Songti SC Light}
+% \setCJKmonofont{Songti SC Light}
+% \setCJKfamilyfont{hei}{Heiti SC Light} %黑体  hei
 \newcommand{\hei}{\CJKfamily{hei}}
 \setlength{\tabcolsep}{3pt}
 \usepackage[hang]{caption2}


### PR DESCRIPTION
Mac 宋体、黑体字体名称与 Windows 不同，Mac下使用需要修改字体名称